### PR TITLE
Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
   "require": {
     "php": ">=5.5.9",
     "arrilot/data-anonymization": "~1.0",
-    "illuminate/support": "5.*|6.*",
-    "illuminate/contracts": "5.*|6.*",
-    "illuminate/console": "5.*|6.*"
+    "illuminate/support": "5.*|6.*|7.*",
+    "illuminate/contracts": "5.*|6.*|7.*",
+    "illuminate/console": "5.*|6.*|7.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Updates version constraints on Illuminate dependencies to support Laravel version 7.